### PR TITLE
Don't add newlines in elements with phrasing content

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,12 @@ go install github.com/a-h/htmlformat/cmd/htmlformat@latest
 ### CLI
 
 ```bash
-echo '<ol><li style="&">A</li><li>B</li></ol>' | htmlformat
+echo '<ol><li style="&"><em>A</em></li><li>B</li></ol>' | htmlformat
 <ol>
  <li style="&">
-  A
+  <em>A</em>
  </li>
- <li>
-  B
- </li>
+ <li>B</li>
 </ol>
 ```
 

--- a/format.go
+++ b/format.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
@@ -109,17 +111,34 @@ func isVoidElement(n *html.Node) bool {
 	return false
 }
 
+func getFirstRune(s string) rune {
+	r, _ := utf8.DecodeRuneInString(s)
+	return r
+}
+
+func hasSingleTextChild(n *html.Node) bool {
+	return n != nil && n.FirstChild != nil && n.FirstChild == n.LastChild && n.FirstChild.Type == html.TextNode
+}
+
 func printNode(w io.Writer, n *html.Node, level int) (err error) {
 	switch n.Type {
 	case html.TextNode:
 		s := n.Data
 		s = strings.TrimSpace(s)
 		if s != "" {
-			if err = printIndent(w, level); err != nil {
+			if !hasSingleTextChild(n.Parent) &&
+				(n.PrevSibling == nil || !unicode.IsPunct(getFirstRune(s))) {
+				if err = printIndent(w, level); err != nil {
+					return
+				}
+			}
+			if _, err = fmt.Fprint(w, s); err != nil {
 				return
 			}
-			if _, err = fmt.Fprintln(w, s); err != nil {
-				return
+			if !hasSingleTextChild(n.Parent) {
+				if _, err = fmt.Fprint(w, "\n"); err != nil {
+					return
+				}
 			}
 		}
 	case html.ElementNode:
@@ -135,18 +154,32 @@ func printNode(w io.Writer, n *html.Node, level int) (err error) {
 				return
 			}
 		}
-		if _, err = fmt.Fprintln(w, ">"); err != nil {
+		if _, err = fmt.Fprint(w, ">"); err != nil {
 			return
+		}
+		if !hasSingleTextChild(n) {
+			if _, err = fmt.Fprint(w, "\n"); err != nil {
+				return
+			}
 		}
 		if !isVoidElement(n) {
 			if err = printChildren(w, n, level+1); err != nil {
 				return
 			}
-			if err = printIndent(w, level); err != nil {
+			if !hasSingleTextChild(n) {
+				if err = printIndent(w, level); err != nil {
+					return
+				}
+			}
+			if _, err = fmt.Fprintf(w, "</%s>", n.Data); err != nil {
 				return
 			}
-			if _, err = fmt.Fprintf(w, "</%s>\n", n.Data); err != nil {
-				return
+
+			if n.NextSibling == nil ||
+				(!unicode.IsPunct(getFirstRune(n.NextSibling.Data)) || n.NextSibling.Type == html.ElementNode) {
+				if _, err = fmt.Fprint(w, "\n"); err != nil {
+					return
+				}
 			}
 		}
 	case html.CommentNode:

--- a/format_test.go
+++ b/format_test.go
@@ -24,12 +24,8 @@ func TestFormat(t *testing.T) {
 			name:  "html attribute escaping is normalized",
 			input: `<ol> <li style="&amp;&#38;"> A </li> <li> B </li> </ol> `,
 			expected: `<ol>
- <li style="&amp;&amp;">
-  A
- </li>
- <li>
-  B
- </li>
+ <li style="&amp;&amp;">A</li>
+ <li>B</li>
 </ol>
 `,
 		},
@@ -37,12 +33,8 @@ func TestFormat(t *testing.T) {
 			name:  "bare ampersands are escaped",
 			input: `<ol> <li style="&"> A </li> <li> B </li> </ol> `,
 			expected: `<ol>
- <li style="&amp;">
-  A
- </li>
- <li>
-  B
- </li>
+ <li style="&amp;">A</li>
+ <li>B</li>
 </ol>
 `,
 		},
@@ -50,12 +42,8 @@ func TestFormat(t *testing.T) {
 			name:  "html elements are indented",
 			input: `<ol> <li class="name"> A </li> <li> B </li> </ol> `,
 			expected: `<ol>
- <li class="name">
-  A
- </li>
- <li>
-  B
- </li>
+ <li class="name">A</li>
+ <li>B</li>
 </ol>
 `,
 		},
@@ -63,6 +51,16 @@ func TestFormat(t *testing.T) {
 			name:     "text fragments are supported",
 			input:    `test 123`,
 			expected: `test 123` + "\n",
+		},
+		{
+			name:  "phrasing content element children are kept on the same line, including punctuation",
+			input: `<ul><li><a href="http://example.com">Test</a>.</li></ul>`,
+			expected: `<ul>
+ <li>
+  <a href="http://example.com">Test</a>.
+ </li>
+</ul>
+`,
 		},
 	}
 


### PR DESCRIPTION
I noticed that links created by `<a>` tags, when underlined, would have spaces around them when using this tool, which looks odd to me.

This PR makes it so I made it so that in the case of elements with phrasing content[^1], the element's text is printed on the same line as the element's start and end tags. The rendered output then looks the same as `prettier`'s, although that tool has an odd-looking approach to long lines:

```html
<a href="http://example.com/this/url/is/ment/to/be/very/long"
  >Link Text</a
>
```

[^1]: I'm not certain whether phrasing content is the right category, but the output doesn't look bad at all